### PR TITLE
Implemented new functionality as per the new design

### DIFF
--- a/core/websocket/ConnectionMetadata.cpp
+++ b/core/websocket/ConnectionMetadata.cpp
@@ -3,58 +3,55 @@
 #include "websocketpp/config/asio_no_tls_client.hpp"
 #include "ConnectionMetadata.hpp"
 //#include "../datastore/DataManager.hpp"
-#include <nlohmann/json.hpp>
 #include <utility>
+#include "mutex"
 
-namespace CAEMonitoringTool::Websocket{
-using json = nlohmann::json;
+namespace CAEMonitoringTool::Websocket {
 
-typedef websocketpp::client<websocketpp::config::asio_client> client;
+    typedef websocketpp::client<websocketpp::config::asio_client> client;
 
-typedef websocketpp::lib::shared_ptr<ConnectionMetadata> ptr;
+    typedef websocketpp::lib::shared_ptr<ConnectionMetadata> ptr;
 
-ConnectionMetadata::ConnectionMetadata(int id, websocketpp::connection_hdl hdl, std::string uri)
-        : m_id(id), m_hdl(std::move(std::move(hdl))), m_status("Connecting"), m_uri(std::move(uri)), m_server("N/A") {}
+    ConnectionMetadata::ConnectionMetadata(int id, websocketpp::connection_hdl hdl, std::string uri)
+            : m_id(id), m_hdl(std::move(std::move(hdl))), m_status("Connecting"), m_uri(std::move(uri)),
+              m_server("N/A") {}
 
-void ConnectionMetadata::onOpen(client *c, websocketpp::connection_hdl hdl) {
-    m_status = "Open";
-    client::connection_ptr con = c->get_con_from_hdl(std::move(hdl));
-    m_server = con->get_response_header("Server");
-}
-
-void ConnectionMetadata::onFail(client *c, websocketpp::connection_hdl hdl) {
-    m_status = "Failed";
-
-    client::connection_ptr con = c->get_con_from_hdl(std::move(hdl));
-    m_server = con->get_response_header("Server");
-    m_error_reason = con->get_ec().message();
-}
-
-void ConnectionMetadata::onClose(client *c, websocketpp::connection_hdl hdl) {
-    m_status = "Closed";
-    client::connection_ptr con = c->get_con_from_hdl(std::move(hdl));
-    std::stringstream s;
-    s << "close code: " << con->get_remote_close_code() << " ("
-      << websocketpp::close::status::get_string(con->get_remote_close_code())
-      << "), close reason: " << con->get_remote_close_reason();
-    m_error_reason = s.str();
-}
-
-void ConnectionMetadata::onMessage(const websocketpp::connection_hdl& hdl, const client::message_ptr& msg) {
-    if (msg->get_opcode() == websocketpp::frame::opcode::text) {
-
-        json j = json::parse(msg->get_payload());
-        std::cout << msg->get_payload() << std::endl;
-        //DataManager::addThreadInfo(j);
-        m_messages.push_back(msg->get_payload());
-    } else {
-        m_messages.push_back(websocketpp::utility::to_hex(msg->get_payload()));
+    void ConnectionMetadata::onOpen(client *c, websocketpp::connection_hdl hdl) {
+        m_status = "Open";
+        client::connection_ptr con = c->get_con_from_hdl(std::move(hdl));
+        m_server = con->get_response_header("Server");
     }
-}
 
-websocketpp::connection_hdl ConnectionMetadata::getHdl() { return m_hdl; }
+    void ConnectionMetadata::onFail(client *c, websocketpp::connection_hdl hdl) {
+        m_status = "Failed";
 
-std::string ConnectionMetadata::getStatus() { return m_status; }
+        client::connection_ptr con = c->get_con_from_hdl(std::move(hdl));
+        m_server = con->get_response_header("Server");
+        m_error_reason = con->get_ec().message();
+    }
 
-int ConnectionMetadata::getId() const { return m_id; }
+    void ConnectionMetadata::onClose(client *c, websocketpp::connection_hdl hdl) {
+        m_status = "Closed";
+        client::connection_ptr con = c->get_con_from_hdl(std::move(hdl));
+        std::stringstream s;
+        s << "close code: " << con->get_remote_close_code() << " ("
+          << websocketpp::close::status::get_string(con->get_remote_close_code())
+          << "), close reason: " << con->get_remote_close_reason();
+        m_error_reason = s.str();
+    }
+
+    void ConnectionMetadata::onMessage(const websocketpp::connection_hdl &hdl, const client::message_ptr &msg) {
+        std::lock_guard<std::mutex> lk(m_messageMutex);
+        m_messages.push_back(msg->get_payload());
+    }
+
+    websocketpp::connection_hdl ConnectionMetadata::getHdl() { return m_hdl; }
+
+    std::string ConnectionMetadata::getStatus() { return m_status; }
+
+    int ConnectionMetadata::getId() const { return m_id; }
+
+    std::deque<std::string>& ConnectionMetadata::getMessageQueue() {
+        return m_messages;
+    }
 }

--- a/core/websocket/ConnectionMetadata.hpp
+++ b/core/websocket/ConnectionMetadata.hpp
@@ -1,11 +1,13 @@
 
 #ifndef CAE_PERFORMANCE_DATA_MONITORING_TOOL_CONNECTIONMETADATA_HPP
 #define CAE_PERFORMANCE_DATA_MONITORING_TOOL_CONNECTIONMETADATA_HPP
+
 #include "websocketpp/client.hpp"
 #include "websocketpp/config/asio_no_tls_client.hpp"
 
 namespace CAEMonitoringTool::Websocket {
     typedef websocketpp::client<websocketpp::config::asio_client> client;
+
 /**
  *  Tracks information about connections.
  */
@@ -47,6 +49,12 @@ namespace CAEMonitoringTool::Websocket {
          */
         [[nodiscard]] int getId() const;
 
+        /**
+         * @return a reference to the message queue
+         */
+        std::deque<std::string>& getMessageQueue();
+
+        std::mutex m_messageMutex;
     private:
         int m_id;
         websocketpp::connection_hdl m_hdl;
@@ -54,7 +62,7 @@ namespace CAEMonitoringTool::Websocket {
         std::string m_uri;
         std::string m_server;
         std::string m_error_reason;
-        std::vector<std::string> m_messages;
+        std::deque<std::string> m_messages;
     };
 }
 #endif //CAE_PERFORMANCE_DATA_MONITORING_TOOL_CONNECTIONMETADATA_HPP

--- a/core/websocket/WebsocketEndpoint.cpp
+++ b/core/websocket/WebsocketEndpoint.cpp
@@ -3,6 +3,7 @@
 #include "websocketpp/config/asio_no_tls_client.hpp"
 #include "WebsocketEndpoint.hpp"
 #include "ConnectionMetadata.hpp"
+#include "queue"
 
 namespace CAEMonitoringTool::Websocket {
 
@@ -114,6 +115,15 @@ namespace CAEMonitoringTool::Websocket {
         if (ec) {
             std::cout << "> Error initiating close: " << ec.message() << std::endl;
         }
+    }
+
+    std::string WebsocketEndpoint::getMessage(int id) const{
+        std::lock_guard<std::mutex> lk(this->getMetadata(id)->m_messageMutex);
+        std::deque<std::string>& queue = this->getMetadata(id)->getMessageQueue();
+        if(queue.empty()) return "";
+        std::string message = queue.front();
+        queue.pop_front();
+        return message;
     }
 }
 

--- a/core/websocket/WebsocketEndpoint.hpp
+++ b/core/websocket/WebsocketEndpoint.hpp
@@ -4,6 +4,7 @@
 #include "websocketpp/client.hpp"
 #include "websocketpp/config/asio_no_tls_client.hpp"
 #include "ConnectionMetadata.hpp"
+#include "mutex"
 
 namespace CAEMonitoringTool::Websocket{
 
@@ -53,6 +54,12 @@ public:
      * @param reason the reason in human readable form.
      */
     void close(int id, websocketpp::close::status::value code, const std::string& reason);
+
+    /**
+     * Gets a message from the queue
+     * @return the message string if one is present, otherwise an empty string.
+     */
+    std::string getMessage(int id) const;
 
 private:
     typedef std::map<int, ConnectionMetadata::ptr> con_list;

--- a/core/websocket/test.cpp
+++ b/core/websocket/test.cpp
@@ -12,8 +12,13 @@ int main() {
     if (id != -1) {
         std::cout << "> Created connection with id " << id << std::endl;
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    endpoint.send(id, "HIHIHI");
-    //endpoint.close(0,websocketpp::close::status::going_away, "");
+    //std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    //endpoint.send(id, "HIHIHI");
+
+    while(true) {
+        std::cout << endpoint.getMessage(id) << std::endl << std::endl;
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+    endpoint.close(id,websocketpp::close::status::going_away, "");
     return 0;
 }


### PR DESCRIPTION
Removed Json parsing and added a queue for messages instead of a list.
getMessage(int id) in Websocket::Endpoint returns the first element of this queue and removes it.  (The id is the id of the connection, most probably 0 in our case). If the queue is empty, getMessage returns an empty std::string.